### PR TITLE
dock: Disallow move panel when it is zoomed in.

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -261,7 +261,7 @@ impl TabPanel {
 
     /// Return true if the panel can be split or move
     fn can_split(&self) -> bool {
-        self.stack_panel.is_some()
+        self.stack_panel.is_some() && !self.is_zoomed
     }
 
     pub(super) fn set_collapsed(&mut self, collapsed: bool, cx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Closes #342 