### PR TITLE
resizable: Fix the bug for parent groups when initializing Panels with sizes Some and None

### DIFF
--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -366,13 +366,16 @@ impl Render for ResizablePanel {
                 this.when(self.size.is_none(), |this| this.flex_shrink_0())
                     .flex_basis(size)
             })
-            .map(|this| {
-                if let Some(size_ratio) = self.size_ratio {
-                    this.flex_basis(relative(size_ratio))
-                } else {
-                    this.when_some(self.size, |this, size| this.flex_basis(size))
-                }
-            })
+            .map(
+                |this| match (self.size_ratio, self.size, self.group.as_ref()) {
+                    (Some(size_ratio), _, _) => this.flex_basis(relative(size_ratio)),
+                    (None, Some(size), Some(group)) => {
+                        this.flex_basis(relative(size / group.read(cx).total_size()))
+                    }
+                    (None, Some(size), None) => this.flex_basis(size),
+                    _ => this,
+                },
+            )
             .child({
                 canvas(
                     move |bounds, cx| view.update(cx, |r, cx| r.update_size(bounds, cx)),

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -366,8 +366,12 @@ impl Render for ResizablePanel {
                 this.when(self.size.is_none(), |this| this.flex_shrink_0())
                     .flex_basis(size)
             })
-            .when_some(self.size_ratio, |this, size_ratio| {
-                this.flex_basis(relative(size_ratio))
+            .map(|this| {
+                if let Some(size_ratio) = self.size_ratio {
+                    this.flex_basis(relative(size_ratio))
+                } else {
+                    this.when_some(self.size, |this, size| this.flex_basis(size))
+                }
             })
             .child({
                 canvas(

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -351,6 +351,7 @@ impl FluentBuilder for ResizablePanel {}
 impl Render for ResizablePanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let view = cx.view().clone();
+        let total_size = self.group.and_then(|group| group.read(cx).total_size());
 
         div()
             .flex()
@@ -367,10 +368,10 @@ impl Render for ResizablePanel {
                     .flex_basis(size)
             })
             .map(
-                |this| match (self.size_ratio, self.size, self.group.as_ref()) {
+                |this| match (self.size_ratio, self.size, total_size) {
                     (Some(size_ratio), _, _) => this.flex_basis(relative(size_ratio)),
-                    (None, Some(size), Some(group)) => {
-                        this.flex_basis(relative(size / group.read(cx).total_size()))
+                    (None, Some(size), Some(total_size)) => {
+                        this.flex_basis(relative(size / total_size))
                     }
                     (None, Some(size), None) => this.flex_basis(size),
                     _ => this,

--- a/crates/ui/src/resizable/panel.rs
+++ b/crates/ui/src/resizable/panel.rs
@@ -351,8 +351,8 @@ impl FluentBuilder for ResizablePanel {}
 impl Render for ResizablePanel {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let view = cx.view().clone();
-        let total_size = self.group.and_then(|group| group.read(cx).total_size());
-
+        let total_size = self.group.as_ref().map(|group| group.read(cx).total_size());
+        
         div()
             .flex()
             .flex_grow()


### PR DESCRIPTION
Optimization of https://github.com/longbridgeapp/gpui-component/pull/329

The issue with the initial width of the Panel has been optimised to ensure that the left side of a Panel combination like [Some(px(510.)), None] is initially rendered with a width of 510px.