### PR TITLE
table: Add `cx` argument to TableDelegate methods.

### DIFF
--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -2,9 +2,9 @@ use std::time::{self, Duration};
 
 use fake::{Fake, Faker};
 use gpui::{
-    div, impl_actions, px, AnyElement, Edges, InteractiveElement, IntoElement, ParentElement,
-    Pixels, Render, SharedString, Styled, Timer, View, ViewContext, VisualContext as _,
-    WindowContext,
+    div, impl_actions, px, AnyElement, AppContext, Edges, InteractiveElement, IntoElement,
+    ParentElement, Pixels, Render, SharedString, Styled, Timer, View, ViewContext,
+    VisualContext as _, WindowContext,
 };
 use serde::Deserialize;
 use ui::{
@@ -283,7 +283,7 @@ impl TableDelegate for StockTableDelegate {
         self.columns.len()
     }
 
-    fn rows_count(&self) -> usize {
+    fn rows_count(&self, _: &'_ AppContext) -> usize {
         self.stocks.len()
     }
 
@@ -683,6 +683,7 @@ impl TableStory {
 impl Render for TableStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl gpui::IntoElement {
         let delegate = self.table.read(cx).delegate();
+        let delegate_size = delegate.rows_count(cx);
         let size = self.size;
 
         v_flex()
@@ -787,7 +788,7 @@ impl Render for TableStory {
                         .when(delegate.loading, |this| {
                             this.child(h_flex().gap_1().child(Indicator::new()).child("Loading..."))
                         })
-                        .child(format!("Total Rows: {}", delegate.rows_count()))
+                        .child(format!("Total Rows: {}", delegate_size))
                         .when(delegate.is_eof, |this| this.child("All data loaded.")),
                 ),
             )

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -683,7 +683,7 @@ impl TableStory {
 impl Render for TableStory {
     fn render(&mut self, cx: &mut ViewContext<Self>) -> impl gpui::IntoElement {
         let delegate = self.table.read(cx).delegate();
-        let delegate_size = delegate.rows_count(cx);
+        let rows_count = delegate.rows_count(cx);
         let size = self.size;
 
         v_flex()
@@ -788,7 +788,7 @@ impl Render for TableStory {
                         .when(delegate.loading, |this| {
                             this.child(h_flex().gap_1().child(Indicator::new()).child("Loading..."))
                         })
-                        .child(format!("Total Rows: {}", delegate_size))
+                        .child(format!("Total Rows: {}", rows_count))
                         .when(delegate.is_eof, |this| this.child("All data loaded.")),
                 ),
             )

--- a/crates/story/src/table_story.rs
+++ b/crates/story/src/table_story.rs
@@ -279,15 +279,15 @@ impl StockTableDelegate {
 }
 
 impl TableDelegate for StockTableDelegate {
-    fn cols_count(&self) -> usize {
+    fn cols_count(&self, _: &AppContext) -> usize {
         self.columns.len()
     }
 
-    fn rows_count(&self, _: &'_ AppContext) -> usize {
+    fn rows_count(&self, _: &AppContext) -> usize {
         self.stocks.len()
     }
 
-    fn col_name(&self, col_ix: usize) -> SharedString {
+    fn col_name(&self, col_ix: usize, _: &AppContext) -> SharedString {
         if let Some(col) = self.columns.get(col_ix) {
             col.name.clone()
         } else {
@@ -295,7 +295,7 @@ impl TableDelegate for StockTableDelegate {
         }
     }
 
-    fn col_width(&self, col_ix: usize) -> Option<Pixels> {
+    fn col_width(&self, col_ix: usize, _: &AppContext) -> Option<Pixels> {
         if let Some(_) = self.columns.get(col_ix) {
             Some(120.0.into())
         } else {
@@ -303,7 +303,7 @@ impl TableDelegate for StockTableDelegate {
         }
     }
 
-    fn col_padding(&self, col_ix: usize) -> Option<Edges<Pixels>> {
+    fn col_padding(&self, col_ix: usize, _: &AppContext) -> Option<Edges<Pixels>> {
         if col_ix >= 3 && col_ix <= 10 {
             Some(Edges::all(px(0.)))
         } else {
@@ -311,7 +311,7 @@ impl TableDelegate for StockTableDelegate {
         }
     }
 
-    fn col_fixed(&self, col_ix: usize) -> Option<ui::table::ColFixed> {
+    fn col_fixed(&self, col_ix: usize, _: &AppContext) -> Option<ui::table::ColFixed> {
         if !self.fixed_cols {
             return None;
         }
@@ -323,16 +323,16 @@ impl TableDelegate for StockTableDelegate {
         }
     }
 
-    fn can_resize_col(&self, col_ix: usize) -> bool {
+    fn can_resize_col(&self, col_ix: usize, _: &AppContext) -> bool {
         return self.col_resize && col_ix > 1;
     }
 
-    fn can_select_col(&self, _: usize) -> bool {
+    fn can_select_col(&self, _: usize, _: &AppContext) -> bool {
         return self.col_selection;
     }
 
-    fn render_th(&self, col_ix: usize, _cx: &mut ViewContext<Table<Self>>) -> impl IntoElement {
-        let th = div().child(self.col_name(col_ix));
+    fn render_th(&self, col_ix: usize, cx: &mut ViewContext<Table<Self>>) -> impl IntoElement {
+        let th = div().child(self.col_name(col_ix, cx));
 
         if col_ix >= 3 && col_ix <= 10 {
             th.table_cell_size(self.size)
@@ -418,20 +418,20 @@ impl TableDelegate for StockTableDelegate {
         }
     }
 
-    fn can_loop_select(&self) -> bool {
+    fn can_loop_select(&self, _: &AppContext) -> bool {
         self.loop_selection
     }
 
-    fn can_move_col(&self, _: usize) -> bool {
+    fn can_move_col(&self, _: usize, _: &AppContext) -> bool {
         self.col_order
     }
 
-    fn move_col(&mut self, col_ix: usize, to_ix: usize) {
+    fn move_col(&mut self, col_ix: usize, to_ix: usize, _: &mut ViewContext<Table<Self>>) {
         let col = self.columns.remove(col_ix);
         self.columns.insert(to_ix, col);
     }
 
-    fn col_sort(&self, col_ix: usize) -> Option<ColSort> {
+    fn col_sort(&self, col_ix: usize, _: &AppContext) -> Option<ColSort> {
         if !self.col_sort {
             return None;
         }
@@ -458,7 +458,7 @@ impl TableDelegate for StockTableDelegate {
         }
     }
 
-    fn can_load_more(&self) -> bool {
+    fn can_load_more(&self, _: &AppContext) -> bool {
         return !self.loading && !self.is_eof;
     }
 

--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -137,7 +137,7 @@ pub trait TableDelegate: Sized + 'static {
     /// Return the number of columns in the table.
     fn cols_count(&self) -> usize;
     /// Return the number of rows in the table.
-    fn rows_count(&self) -> usize;
+    fn rows_count(&self, cx: &'_ AppContext) -> usize;
 
     /// Returns the name of the column at the given index.
     fn col_name(&self, col_ix: usize) -> SharedString;
@@ -377,7 +377,7 @@ where
 
     fn action_select_prev(&mut self, _: &SelectPrev, cx: &mut ViewContext<Self>) {
         let mut selected_row = self.selected_row.unwrap_or(0);
-        let rows_count = self.delegate.rows_count();
+        let rows_count = self.delegate.rows_count(cx);
         if selected_row > 0 {
             selected_row = selected_row - 1;
         } else {
@@ -391,7 +391,7 @@ where
 
     fn action_select_next(&mut self, _: &SelectNext, cx: &mut ViewContext<Self>) {
         let mut selected_row = self.selected_row.unwrap_or(0);
-        if selected_row < self.delegate.rows_count() - 1 {
+        if selected_row < self.delegate.rows_count(cx) - 1 {
             selected_row += 1;
         } else {
             if self.delegate.can_loop_select() {
@@ -523,7 +523,7 @@ where
             return;
         }
 
-        let row_count = self.delegate.rows_count();
+        let row_count = self.delegate.rows_count(cx);
         let load_more_count = self.delegate.load_more_threshold();
 
         // Securely handle subtract logic to prevent attempt to subtract with overflow
@@ -1055,7 +1055,7 @@ where
         let vertical_scroll_handle = self.vertical_scroll_handle.clone();
         let horizontal_scroll_handle = self.horizontal_scroll_handle.clone();
         let cols_count: usize = self.delegate.cols_count();
-        let rows_count = self.delegate.rows_count();
+        let rows_count = self.delegate.rows_count(cx);
 
         let row_height = self
             .vertical_scroll_handle


### PR DESCRIPTION
As discussed in #359 adds a `AppContext` argument to the `table::TableDelegate::rows_count` method