### PR TITLE
dock: Add `panel_style` to support always show TabBar.

### DIFF
--- a/crates/app/src/story_workspace.rs
+++ b/crates/app/src/story_workspace.rs
@@ -11,7 +11,7 @@ use story::{
 use ui::{
     button::{Button, ButtonStyled as _},
     color_picker::{ColorPicker, ColorPickerEvent},
-    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement},
+    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement, PanelStyle},
     h_flex,
     popup_menu::PopupMenuExt,
     theme::{ActiveTheme, Theme},
@@ -70,8 +70,10 @@ impl StoryWorkspace {
         })
         .detach();
 
-        let dock_area =
-            cx.new_view(|cx| DockArea::new(MAIN_DOCK_AREA.id, Some(MAIN_DOCK_AREA.version), cx));
+        let dock_area = cx.new_view(|cx| {
+            DockArea::new(MAIN_DOCK_AREA.id, Some(MAIN_DOCK_AREA.version), cx)
+                .panel_style(PanelStyle::Tab)
+        });
         let weak_dock_area = dock_area.downgrade();
 
         match Self::load_layout(dock_area.clone(), cx) {

--- a/crates/app/src/story_workspace.rs
+++ b/crates/app/src/story_workspace.rs
@@ -70,10 +70,8 @@ impl StoryWorkspace {
         })
         .detach();
 
-        let dock_area = cx.new_view(|cx| {
-            DockArea::new(MAIN_DOCK_AREA.id, Some(MAIN_DOCK_AREA.version), cx)
-                .panel_style(PanelStyle::Tab)
-        });
+        let dock_area =
+            cx.new_view(|cx| DockArea::new(MAIN_DOCK_AREA.id, Some(MAIN_DOCK_AREA.version), cx));
         let weak_dock_area = dock_area.downgrade();
 
         match Self::load_layout(dock_area.clone(), cx) {

--- a/crates/app/src/story_workspace.rs
+++ b/crates/app/src/story_workspace.rs
@@ -11,7 +11,7 @@ use story::{
 use ui::{
     button::{Button, ButtonStyled as _},
     color_picker::{ColorPicker, ColorPickerEvent},
-    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement, PanelStyle},
+    dock::{DockArea, DockAreaState, DockEvent, DockItem, DockPlacement},
     h_flex,
     popup_menu::PopupMenuExt,
     theme::{ActiveTheme, Theme},

--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -34,14 +34,6 @@ pub enum DockEvent {
     LayoutChanged,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PanelStyle {
-    /// When only have one panel, the panel will not display the tab bar.
-    Default,
-    /// Always display the tab bar.
-    Tab,
-}
-
 /// The main area of the dock.
 pub struct DockArea {
     id: SharedString,

--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -34,30 +34,41 @@ pub enum DockEvent {
     LayoutChanged,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PanelStyle {
+    /// When only have one panel, the panel will not display the tab bar.
+    Default,
+    /// Always display the tab bar.
+    Tab,
+}
+
 /// The main area of the dock.
 pub struct DockArea {
     id: SharedString,
-    /// The version is used to special the default layout, this is like the `panel_version` in `trait Panel`.
+    /// The version is used to special the default layout, this is like the `panel_version` in [`Panel`](Panel).
     version: Option<usize>,
     pub(crate) bounds: Bounds<Pixels>,
 
     /// The center view of the dockarea.
     items: DockItem,
 
-    /// The entity_id of the TabPanel where each toggle button should be displayed,
+    /// The entity_id of the [`TabPanel`](TabPanel) where each toggle button should be displayed,
     toggle_button_panels: Edges<Option<EntityId>>,
 
-    /// The left dock of the dockarea.
+    /// The left dock of the dock_area.
     left_dock: Option<View<Dock>>,
-    /// The bottom dock of the dockarea.
+    /// The bottom dock of the dock_area.
     bottom_dock: Option<View<Dock>>,
-    /// The right dock of the dockarea.
+    /// The right dock of the dock_area.
     right_dock: Option<View<Dock>>,
-    /// The top zoom view of the dockarea, if any.
+    /// The top zoom view of the dock_area, if any.
     zoom_view: Option<AnyView>,
 
     /// Lock panels layout, but allow to resize.
     is_locked: bool,
+
+    /// The panel style, default is [`PanelStyle::Default`](PanelStyle::Default).
+    pub(crate) panel_style: PanelStyle,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -296,12 +307,19 @@ impl DockArea {
             right_dock: None,
             bottom_dock: None,
             is_locked: false,
+            panel_style: PanelStyle::Default,
             _subscriptions: vec![],
         };
 
         this.subscribe_panel(&stack_panel, cx);
 
         this
+    }
+
+    /// Set the panel style of the dock area.
+    pub fn panel_style(mut self, style: PanelStyle) -> Self {
+        self.panel_style = style;
+        self
     }
 
     /// Set version of the dock area.

--- a/crates/ui/src/dock/panel.rs
+++ b/crates/ui/src/dock/panel.rs
@@ -16,6 +16,15 @@ pub enum PanelEvent {
     LayoutChanged,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PanelStyle {
+    /// Display the TabBar when there are multiple tabs, otherwise display the simple title.
+    Default,
+    /// Always display the tab bar.
+    TabBar,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TitleStyle {
     pub background: Hsla,
     pub foreground: Hsla,

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -20,8 +20,8 @@ use crate::{
 };
 
 use super::{
-    ClosePanel, DockArea, DockItemState, DockPlacement, Panel, PanelEvent, PanelView, StackPanel,
-    ToggleZoom,
+    ClosePanel, DockArea, DockItemState, DockPlacement, Panel, PanelEvent, PanelStyle, PanelView,
+    StackPanel, ToggleZoom,
 };
 
 #[derive(Clone, Copy)]
@@ -455,11 +455,16 @@ impl TabPanel {
     fn render_title_bar(&self, state: TabState, cx: &mut ViewContext<Self>) -> impl IntoElement {
         let view = cx.view().clone();
 
+        let Some(dock_area) = self.dock_area.upgrade() else {
+            return div().into_any_element();
+        };
+        let panel_style = dock_area.read(cx).panel_style;
+
         let left_dock_button = self.render_dock_toggle_button(DockPlacement::Left, cx);
         let bottom_dock_button = self.render_dock_toggle_button(DockPlacement::Bottom, cx);
         let right_dock_button = self.render_dock_toggle_button(DockPlacement::Right, cx);
 
-        if self.panels.len() == 1 {
+        if self.panels.len() == 1 && panel_style == PanelStyle::Default {
             let panel = self.panels.get(0).unwrap();
             let title_style = panel.title_style(cx);
 


### PR DESCRIPTION
Close #441 

```rs
DockArea::new(MAIN_DOCK_AREA.id, Some(MAIN_DOCK_AREA.version), cx).panel_style(PanelStyle::TabBar)
```

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/2013188e-990b-4709-ac7e-43c2de8bc895">
