### PR TITLE
panel: Fix toggle button border overlap with first tab.

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -534,7 +534,8 @@ impl TabPanel {
                         h_flex()
                             .items_center()
                             .top_0()
-                            .right_0()
+                            // Right -1 for avoid border overlap with the first tab
+                            .right(-px(1.))
                             .border_r_1()
                             .border_b_1()
                             .h_full()


### PR DESCRIPTION
<img width="202" alt="image" src="https://github.com/user-attachments/assets/ab7b9865-52be-4bdb-bade-9b0c47e83bb7">
