### PR TITLE
dock: Fix some panel cannot able to split

### DIFF
--- a/crates/app/src/story_workspace.rs
+++ b/crates/app/src/story_workspace.rs
@@ -224,12 +224,7 @@ impl StoryWorkspace {
         let left_panels = DockItem::split_with_sizes(
             Axis::Vertical,
             vec![
-                DockItem::tabs(
-                    vec![Arc::new(StoryContainer::panel::<ListStory>(cx))],
-                    None,
-                    &dock_area,
-                    cx,
-                ),
+                DockItem::tab(StoryContainer::panel::<ListStory>(cx), &dock_area, cx),
                 DockItem::tabs(
                     vec![
                         Arc::new(StoryContainer::panel::<ScrollableStory>(cx)),
@@ -263,15 +258,10 @@ impl StoryWorkspace {
 
         let right_panels = DockItem::split_with_sizes(
             Axis::Vertical,
-            vec![DockItem::tabs(
-                vec![
-                    Arc::new(StoryContainer::panel::<ImageStory>(cx)),
-                    Arc::new(StoryContainer::panel::<IconStory>(cx)),
-                ],
-                None,
-                &dock_area,
-                cx,
-            )],
+            vec![
+                DockItem::tab(StoryContainer::panel::<ImageStory>(cx), &dock_area, cx),
+                DockItem::tab(StoryContainer::panel::<IconStory>(cx), &dock_area, cx),
+            ],
             vec![None],
             &dock_area,
             cx,
@@ -279,7 +269,7 @@ impl StoryWorkspace {
 
         _ = dock_area.update(cx, |view, cx| {
             view.set_version(MAIN_DOCK_AREA.version, cx);
-            view.set_root(dock_item, cx);
+            view.set_center(dock_item, cx);
             view.set_left_dock(left_panels, Some(px(350.)), true, cx);
             view.set_bottom_dock(bottom_panels, Some(px(200.)), true, cx);
             view.set_right_dock(right_panels, Some(px(320.)), true, cx);

--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -320,10 +320,16 @@ impl DockArea {
         cx.notify();
     }
 
-    /// The the DockItem as the root of the dock area.
+    // FIXME: Remove this method after 2025-01-01
+    #[deprecated(note = "Use `set_center` instead")]
+    pub fn set_root(&mut self, item: DockItem, cx: &mut ViewContext<Self>) {
+        self.set_center(item, cx);
+    }
+
+    /// The the DockItem as the center of the dock area.
     ///
     /// This is used to render at the Center of the DockArea.
-    pub fn set_root(&mut self, item: DockItem, cx: &mut ViewContext<Self>) {
+    pub fn set_center(&mut self, item: DockItem, cx: &mut ViewContext<Self>) {
         self.subscribe_item(&item, cx);
         self.items = item;
         self.update_toggle_button_tab_panels(cx);

--- a/crates/ui/src/dock/stack_panel.rs
+++ b/crates/ui/src/dock/stack_panel.rs
@@ -82,13 +82,17 @@ impl StackPanel {
 
     /// Return true if self or parent only have last panel.
     pub(super) fn is_last_panel(&self, cx: &AppContext) -> bool {
+        if self.panels.len() > 1 {
+            return false;
+        }
+
         if let Some(parent) = &self.parent {
             if let Some(parent) = parent.upgrade() {
                 return parent.read(cx).is_last_panel(cx);
             }
         }
 
-        self.panels.len() == 1
+        true
     }
 
     pub(super) fn panels_len(&self) -> usize {


### PR DESCRIPTION
- Rename `set_root` to `set_center`.