### PR TITLE
dock: Add DockItem::panel

### DIFF
--- a/crates/app/src/story_workspace.rs
+++ b/crates/app/src/story_workspace.rs
@@ -256,7 +256,16 @@ impl StoryWorkspace {
             cx,
         );
 
-        let right_panels = DockItem::panel(Arc::new(StoryContainer::panel::<IconStory>(cx)));
+        let right_panels = DockItem::split_with_sizes(
+            Axis::Vertical,
+            vec![
+                DockItem::tab(StoryContainer::panel::<ImageStory>(cx), &dock_area, cx),
+                DockItem::tab(StoryContainer::panel::<IconStory>(cx), &dock_area, cx),
+            ],
+            vec![None],
+            &dock_area,
+            cx,
+        );
 
         _ = dock_area.update(cx, |view, cx| {
             view.set_version(MAIN_DOCK_AREA.version, cx);

--- a/crates/app/src/story_workspace.rs
+++ b/crates/app/src/story_workspace.rs
@@ -256,16 +256,7 @@ impl StoryWorkspace {
             cx,
         );
 
-        let right_panels = DockItem::split_with_sizes(
-            Axis::Vertical,
-            vec![
-                DockItem::tab(StoryContainer::panel::<ImageStory>(cx), &dock_area, cx),
-                DockItem::tab(StoryContainer::panel::<IconStory>(cx), &dock_area, cx),
-            ],
-            vec![None],
-            &dock_area,
-            cx,
-        );
+        let right_panels = DockItem::panel(Arc::new(StoryContainer::panel::<IconStory>(cx)));
 
         _ = dock_area.update(cx, |view, cx| {
             view.set_version(MAIN_DOCK_AREA.version, cx);

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -188,7 +188,7 @@ impl Dock {
                     }
                 });
             }
-            DockItem::Plain { .. } => {
+            DockItem::Panel { .. } => {
                 // Not supported
             }
         }
@@ -370,7 +370,7 @@ impl Render for Dock {
             .map(|this| match &self.panel {
                 DockItem::Split { view, .. } => this.child(view.clone()),
                 DockItem::Tabs { view, .. } => this.child(view.clone()),
-                DockItem::Plain { view, .. } => this.child(view.clone().view()),
+                DockItem::Panel { view, .. } => this.child(view.clone().view()),
             })
             .child(self.render_resize_handle(cx))
             .child(DockElement {

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -188,6 +188,9 @@ impl Dock {
                     }
                 });
             }
+            DockItem::Plain { .. } => {
+                // Not supported
+            }
         }
     }
 
@@ -367,6 +370,7 @@ impl Render for Dock {
             .map(|this| match &self.panel {
                 DockItem::Split { view, .. } => this.child(view.clone()),
                 DockItem::Tabs { view, .. } => this.child(view.clone()),
+                DockItem::Plain { view, .. } => this.child(view.clone().view()),
             })
             .child(self.render_resize_handle(cx))
             .child(DockElement {

--- a/crates/ui/src/dock/mod.rs
+++ b/crates/ui/src/dock/mod.rs
@@ -81,8 +81,8 @@ pub enum DockItem {
         active_ix: usize,
         view: View<TabPanel>,
     },
-    /// Plain layout, user can put anything which implement PanelView trait
-    Plain { view: Arc<dyn PanelView> },
+    /// Panel layout
+    Panel { view: Arc<dyn PanelView> },
 }
 
 impl DockItem {
@@ -144,9 +144,9 @@ impl DockItem {
         }
     }
 
-    /// Create DockItem with plain layout
-    pub fn plain(panel: Arc<dyn PanelView>) -> Self {
-        Self::Plain { view: panel }
+    /// Create DockItem with panel layout
+    pub fn panel(panel: Arc<dyn PanelView>) -> Self {
+        Self::Panel { view: panel }
     }
 
     /// Create DockItem with tabs layout, items are displayed as tabs.
@@ -201,7 +201,7 @@ impl DockItem {
         match self {
             Self::Split { view, .. } => Arc::new(view.clone()),
             Self::Tabs { view, .. } => Arc::new(view.clone()),
-            Self::Plain { view, .. } => view.clone(),
+            Self::Panel { view, .. } => view.clone(),
         }
     }
 
@@ -212,7 +212,7 @@ impl DockItem {
                 items.iter().find_map(|item| item.find_panel(panel.clone()))
             }
             Self::Tabs { items, .. } => items.iter().find(|item| *item == &panel).cloned(),
-            Self::Plain { view } => Some(view.clone()),
+            Self::Panel { view } => Some(view.clone()),
         }
     }
 
@@ -248,7 +248,7 @@ impl DockItem {
                     stack_panel.add_panel(new_item.view(), None, dock_area.clone(), cx);
                 });
             }
-            Self::Plain { .. } => {}
+            Self::Panel { .. } => {}
         }
     }
 
@@ -265,7 +265,7 @@ impl DockItem {
                     item.set_collapsed(collapsed, cx);
                 }
             }
-            DockItem::Plain { .. } => {}
+            DockItem::Panel { .. } => {}
         }
     }
 
@@ -274,7 +274,7 @@ impl DockItem {
         match self {
             DockItem::Tabs { view, .. } => Some(view.clone()),
             DockItem::Split { view, .. } => view.read(cx).left_top_tab_panel(true, cx),
-            DockItem::Plain { .. } => None,
+            DockItem::Panel { .. } => None,
         }
     }
 
@@ -283,7 +283,7 @@ impl DockItem {
         match self {
             DockItem::Tabs { view, .. } => Some(view.clone()),
             DockItem::Split { view, .. } => view.read(cx).right_top_tab_panel(true, cx),
-            DockItem::Plain { .. } => None,
+            DockItem::Panel { .. } => None,
         }
     }
 }
@@ -655,7 +655,7 @@ impl DockArea {
             DockItem::Tabs { .. } => {
                 // We subscribe to the tab panel event in StackPanel's insert_panel
             }
-            DockItem::Plain { .. } => {
+            DockItem::Panel { .. } => {
                 // Not supported
             }
         }
@@ -725,7 +725,7 @@ impl DockArea {
         match &self.items {
             DockItem::Split { view, .. } => view.clone().into_any_element(),
             DockItem::Tabs { view, .. } => view.clone().into_any_element(),
-            DockItem::Plain { view, .. } => view.clone().view().into_any_element(),
+            DockItem::Panel { view, .. } => view.clone().view().into_any_element(),
         }
     }
 


### PR DESCRIPTION
**Description**:
Improve the flexibility of `DockArea`, sometime user won't need a `TabPanel`, just display some message or UI elements. Curren implement only allow use Tab or Split. So this PR will add `Plain` to `DockItem`, user can put anything which implement `PanelView` trait.

**Usage**:
```rust
let left_panels = DockItem::panel(Arc::new(<- PanelView ->));

_ = dock_area.update(cx, |view, cx| {
    view.set_version(DOCK_AREA.version, cx);
    view.set_left_dock(left_panels, Some(px(260.)), true, cx);
    view.set_center(dock_item, cx);
    view.set_dock_collapsible(
        Edges {
            left: false,
            ..Default::default()
        },
        cx,
    );
});
```

**Screenshot**
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/a01e427c-50f1-4509-82d1-76cc016aa7b3">
