### PR TITLE
table: Add a theme color to fixed the drag column in dark mode text style

### DIFF
--- a/crates/ui/src/table.rs
+++ b/crates/ui/src/table.rs
@@ -77,6 +77,8 @@ impl Render for DragCol {
             .px_4()
             .py_1()
             .bg(cx.theme().table_head)
+            .text_color(cx.theme().muted_foreground)
+            .opacity(0.9)
             .border_1()
             .border_color(cx.theme().border)
             .shadow_md()


### PR DESCRIPTION
Before:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/21e00ac4-7617-47e2-865f-bb3d9816b921">


After:
<img width="707" alt="image" src="https://github.com/user-attachments/assets/65c1d0a5-a207-4c2f-b579-aa27096dea4b">
